### PR TITLE
Allow loading of full flag info for inactive flags

### DIFF
--- a/MonicasFlagToC.user.js
+++ b/MonicasFlagToC.user.js
@@ -710,11 +710,14 @@ function initQuestionPage()
          // historical flag expansion
          .on("click", "a.show-all-flags", function()
          {
-            var postId = $(this)
-               .data('postid');
-            RefreshFlagsForPost(postId, true);
+            var holder = $(this).parent();
+            var postId = $(this).data('postid');
+            
+            RefreshFlagsForPost(postId, true)
+               .then(function() {
+                  holder.find('a.show-all-flags').hide();
+               });
          });
-         
    });
    
    $(document)
@@ -865,7 +868,7 @@ function initQuestionPage()
          let flagSummary = [];
          if (activeCount > 0) flagSummary.push(activeCount + " active post flags");
          if (inactiveCount) flagSummary.push(inactiveCount + " resolved post flags");
-         if (postFlags.assumeInactiveCommentFlagCount) flagSummary.push(`(*<a class='show-all-flags' data-postid='${postFlags.postId}' title='Not sure about these flags; click to load accurate information for ${postFlags.assumeInactiveCommentFlagCount} undefined flags'>load full flag info</a>)`);
+         if (postFlags.assumeInactiveCommentFlagCount || inactiveCount) flagSummary.push(`(*<a class='show-all-flags' data-postid='${postFlags.postId}' title='Not sure about these flags; click to load accurate information for ${postFlags.assumeInactiveCommentFlagCount} undefined flags'>load full flag info</a>)`);
          tools.show()
             .find("h3.flag-summary").html(flagSummary.join("; "));
       }


### PR DESCRIPTION
When a post has a pending and inactive flag, show the 'load full flag info' button so we can see the outcomes of past flags.

Before:

![image](https://user-images.githubusercontent.com/709585/40755463-ed81b3d6-64c1-11e8-8a6f-2e65918a302d.png)

After:

![image](https://user-images.githubusercontent.com/709585/40755470-f18defee-64c1-11e8-9cbd-1120b37f0831.png)

